### PR TITLE
Fix typo on Usage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Using it in your app
 import { createBefter } from "@farming-labs/befter"
 ```
 
-Go and refer to the [Usage](https://farming-lab.vercel.app/docs/befter/usage) section to learn how to use Befter.
+Go and refer to the [Usage](https://farming-labs.vercel.app/docs/befter/usage) section to learn how to use Befter.


### PR DESCRIPTION
I added the correct usage link

- **Incorrect usage link**
   - https://farming-lab.vercel.app/docs/befter/usage
 
- **Correct usage link**
  - https://farming-labS.vercel.app/docs/befter/usage